### PR TITLE
EHC Results Dates and Language

### DIFF
--- a/engineering-health-check/README.md
+++ b/engineering-health-check/README.md
@@ -8,7 +8,7 @@ The 9.x version of the script also optionally collects and generates a summary o
 * Ensure admin privileges before running the scripts
 
 
-cxInsight_XX.ps1 usage
+## cxInsight_XX.ps1 usage
 Open powershell and enter the following replacing XX with the correct version
 ```
 ./cxInsight_XX.ps1
@@ -16,6 +16,10 @@ Open powershell and enter the following replacing XX with the correct version
 * Enter the CxServer Url - ex: https://acme.checkmarx.net
 * Enter administrator credentials for CxSAST
 
+To get more information about the usage, use the `Get-Help` command:
+```
+Get-Help ./cxInsight_XX.ps1
+```
 
 ## Credential Prompt via Command Line
 

--- a/engineering-health-check/README.md
+++ b/engineering-health-check/README.md
@@ -29,3 +29,10 @@ The script prompts for a CxSAST username and password. If your environment does 
 $key = "HKLM:\SOFTWARE\Microsoft\PowerShell\1\ShellIds"
 Set-ItemProperty $key ConsolePrompting True
 ```
+
+## Triage Results
+
+By default, the cxInsight_9.0.ps1 script retrieves only scan data. To also retrieve result triage data, use the `-Results` command line switch:
+```
+./cxInsight_9_0.ps1 -Results
+```

--- a/engineering-health-check/cxInsight_9_0.ps1
+++ b/engineering-health-check/cxInsight_9_0.ps1
@@ -138,7 +138,7 @@ function getResultOData {
         $projects = @{}
         $response | Select-Object -ExpandProperty Value | ForEach-Object {
             $projectId = "$($_.Id)"
-            $lastScanId = "$($_.LastScanId)"
+            $lastScanId = $_.LastScanId
 
             if (-Not $lastScanId) {
                 Write-Verbose "Project ${projectId} has no last scan"

--- a/engineering-health-check/cxInsight_9_0.ps1
+++ b/engineering-health-check/cxInsight_9_0.ps1
@@ -28,7 +28,7 @@ C:\PS> .\cxInsight_9_0.ps1 -cx_sast_server http://localhost -results
 .NOTES
     Author: Checkmarx
     Date:   April 13, 2020
-    Updated: June 8, 2022
+    Updated: June 24, 2022
 #>
 
 param(


### PR DESCRIPTION
This pull request addresses two issues raised by @benjaminstokes:

- State names are in english, and I think this ties us to english environments only.
- Is the result data pulled for every project or time boxed to the 90 days of the EHC?

The answer to the second question was no. To address this, due to either user error or a limitation of the CxSAST OData implementation, I had to change the OData endpoint that we query from `/projects` to `/scans`, filtering on the `LastScanId` property (as well as the `ScanRequestedOn` property). This had the fortuitous side-effect of allowing us to expand the ResultState object, giving us the state name as provided by CxSAST (the OData implementation seems to limit the expansion depth so, with the previous implementation, this was not possible).