### PR TITLE
Triage results for 8.9

### DIFF
--- a/engineering-health-check/README.md
+++ b/engineering-health-check/README.md
@@ -8,17 +8,17 @@ The script also optionally collects and generates a summary of the result data f
 * Ensure admin privileges before running the scripts
 
 
-## cxInsight_XX.ps1 usage
+## cxInsight_X_X.ps1 usage
 Open powershell and enter the following replacing XX with the correct version
 ```
-./cxInsight_XX.ps1
+./cxInsight_X_X.ps1
 ```
 * Enter the CxServer Url - ex: https://acme.checkmarx.net
 * Enter administrator credentials for CxSAST
 
 To get more information about the usage, use the `Get-Help` command:
 ```
-Get-Help ./cxInsight_XX.ps1
+Get-Help ./cxInsight_X_X.ps1
 ```
 
 ## Credential Prompt via Command Line
@@ -32,7 +32,7 @@ Set-ItemProperty $key ConsolePrompting True
 
 ## Triage Results
 
-By default, the cxInsight_9.0.ps1 script retrieves only scan data. To also retrieve result triage data, use the `-Results` command line switch:
+By default, the cxInsight_X_X.ps1 script retrieves only scan data. To also retrieve result triage data, use the `-Results` command line switch:
 ```
-./cxInsight_9_0.ps1 -Results
+./cxInsight_X_X.ps1 -Results
 ```

--- a/engineering-health-check/README.md
+++ b/engineering-health-check/README.md
@@ -9,7 +9,7 @@ The script also optionally collects and generates a summary of the result data f
 
 
 ## cxInsight_X_X.ps1 usage
-Open powershell and enter the following replacing XX with the correct version
+Open powershell and enter the following replacing X_X with the correct version
 ```
 ./cxInsight_X_X.ps1
 ```

--- a/engineering-health-check/README.md
+++ b/engineering-health-check/README.md
@@ -2,7 +2,7 @@
 
 These Powershell scripts are used to retrieve  CxSAST Scan Data for Insight Analysis in the Engineering Health Check.
 The script will collect scan Information that includes data about: Projects, Presets, Teams, Engines, and Result Metrics
-The 9.x version of the script also optionally collects and generates a summary of the result data for the last scan of each project. Note that it is possible for the last scan of a project to have no results (e.g., if there were no code changes).
+The script also optionally collects and generates a summary of the result data for the last full scan of each project. Note that it is possible for the last scan of a project to have no results (e.g., if there were no code changes).
 
 * Use the corresponding script for the version of CxSAST that is installed.
 * Ensure admin privileges before running the scripts

--- a/engineering-health-check/cxInsight_8_9.ps1
+++ b/engineering-health-check/cxInsight_8_9.ps1
@@ -76,7 +76,7 @@ function odata() {
     if ($bypassProxy) {
         $cxargs.NoProxy = $true
     }
-    if ($OutputFile) {
+    if ($OutFile) {
         $cxargs.OutFile = $OutFile
     }
 

--- a/engineering-health-check/cxInsight_8_9.ps1
+++ b/engineering-health-check/cxInsight_8_9.ps1
@@ -1,8 +1,8 @@
-﻿<#
+<#
 .SYNOPSIS
 This is a Powershell script to retrieve your Checkmarx ScanData for Insight Analysis
 .DESCRIPTION
-This script will collect Scan Information that includes data about: Projects, Presets, Teams, Engines, and Result Metrics 
+This script will collect Scan Information that includes data about: Projects, Presets, Teams, Engines, and Result Metrics. It also optionally retrieves scan results and generates a summary of them.
 .PARAMETER cx_sast_server
     URL of the Checkmarx Server (i.e. https://companyname.checkmarx.net or http://localhost).
 .PARAMETER day_span
@@ -11,15 +11,24 @@ This script will collect Scan Information that includes data about: Projects, Pr
     The start date of the date range you would like to collect data (Format: yyyy-mm-DD)
 .PARAMETER end_date
     The end date of the date range you would like to collect data (Format: yyyy-mm-DD)
+.PARAMETER bypassProxy
+    If provided, the script will attempt to bypass any proxy when invoking the CxSAST API
+.PARAMETER results
+    If provided, the script will retrieve and summarize result data as well as scan data
+.PARAMETER verbose
+    If provided, the script will retrieve print activity messages
 .EXAMPLE
     C:\PS> .\cxInsight_8_9.ps1 -cx_sast_server https://customerurl.checkmarx.net
 .EXAMPLE
     C:\PS> .\cxInsight_8_9.ps1 -start_date 2019-04-01
 .EXAMPLE
     C:\PS> .\cxInsight_8_9.ps1 -cx_sast_server http://localhost -day_span 180
+.EXAMPLE
+    C:\PS> .\cxInsight_8_9.ps1 -cx_sast_server http://localhost -results
 .NOTES
     Author: Checkmarx
     Date:   April 13, 2020
+    Updated: July 1, 2022
 #>
 
 param(
@@ -27,9 +36,18 @@ param(
     [String]$cx_sast_server,
     [int]$day_span = 90,
     [String]$start_date = ((Get-Date).AddDays(-$day_span).ToString("yyyy-MM-dd")),
-    [String]$end_date = (Get-Date -format "yyyy-MM-dd")
-    ) 
- 
+    [String]$end_date = (Get-Date -format "yyyy-MM-dd"),
+    [Parameter(Mandatory=$False)]
+    [switch]
+    $bypassProxy,
+    [Parameter(Mandatory=$False)]
+    [switch]
+    $results,
+    [Parameter(Mandatory=$False)]
+    [switch]
+    $AllowUnencryptedAuthenticationresults
+    )
+
 ###### Do Not Change The Following Configs ######
 $grantType = "password"
 $scope = "sast_rest_api"
@@ -37,49 +55,160 @@ $clientId = "resource_owner_client"
 $clientSecret = "014DF517-39D1-4453-B7B3-9930C563627C"
 
 $cred = Get-Credential -Credential $null
-$cxUsername = $cred.UserName
-$pscred = $cred.GetNetworkCredential()
-$cxPassword = $cred.GetNetworkCredential().password
- 
-$body = @{
-    username = $cxUsername
-    password = $cxPassword
-    grant_type = $grantType
-    scope = $scope
-    client_id = $clientId
-    client_secret = $clientSecret
+
+Write-Host "Running Script on Version " (get-host).Version
+#$token = getOAuth2Token
+
+function odata() {
+    param (
+        $Uri,
+        $OutFile
+    )
+
+    $cxargs = @{
+        Uri = $Uri
+        Method = "Get"
+        Credential = $cred
+    }
+    if ($AllowUnencryptedAuthenticationresults) {
+        $cxargs.AllowUnencryptedAuthentication = $true
+    }
+    if ($bypassProxy) {
+        $cxargs.NoProxy = $true
+    }
+    if ($OutputFile) {
+        $cxargs.OutFile = $OutFile
+    }
+
+    return Invoke-RestMethod @cxargs
 }
 
-$Url = "${cx_sast_server}/cxwebinterface/odata/v1/Scans?`$select=Id,ProjectName,OwningTeamId,TeamName,ProductVersion,EngineServerId,Origin,PresetName,ScanRequestedOn,QueuedOn,EngineStartedOn,EngineFinishedOn,ScanCompletedOn,ScanDuration,FileCount,LOC,FailedLOC,TotalVulnerabilities,High,Medium,Low,Info,IsIncremental,IsLocked,IsPublic&`$expand=ScannedLanguages(`$select=LanguageName)&`$filter=ScanRequestedOn%20gt%20${start_date}Z%20and%20ScanRequestedOn%20lt%20${end_date}z"
- 
-try {
-    $response = Invoke-RestMethod -uri $cx_sast_server/cxrestapi/auth/identity/connect/token -method post -body $body -contenttype 'application/x-www-form-urlencoded'
-} catch {
-    Write-Host "StatusCode:" $_.Exception.Response.StatusCode.value__
-    Write-Host "StatusDescription:" $_.Exception.Response.StatusDescription
-    Write-Host ""
-    Write-Host ""
-    Write-Host $Url
-    Read-Host -Prompt "An Error has prevented this script from being successful. Press paste the above Odata query in your browser..."
-    throw "Could not authenticate"
+function getScanOdata {
+    param (
+        $outputFile
+    )
+    Write-Verbose "Retrieving scan data"
+
+    $Url = "${cx_sast_server}/cxwebinterface/odata/v1/Scans?`$select=Id,ProjectId,ProjectName,OwningTeamId,TeamName,ProductVersion,EngineServerId,Origin,PresetName,ScanRequestedOn,QueuedOn,EngineStartedOn,EngineFinishedOn,ScanCompletedOn,ScanDuration,FileCount,LOC,FailedLOC,TotalVulnerabilities,High,Medium,Low,Info,IsIncremental,IsLocked,IsPublic&`$expand=ScannedLanguages(`$select=LanguageName)&`$filter=ScanRequestedOn%20gt%20${start_date}Z%20and%20ScanRequestedOn%20lt%20${end_date}z"
+    try {
+        $response = odata -Uri $Url -OutFile $outputFile
+    }
+    catch {
+        Write-Host "Exception:" $_ -ForegroundColor "Red"
+        Write-Host $_.ScriptStackTrace -ForegroundColor "DarkGray"
+        Write-Host "StatusCode:" $_.Exception.Response.StatusCode.value__
+        Write-Host "StatusDescription:" $_.Exception.Response.StatusDescription
+        Write-Host $Url
+        Write-Host "An error has prevented this script from collecting scan Odata."
+        exit(-1)
+    }
+}
+
+function getResultOData {
+    param (
+        $outputFile
+    )
+    Write-Verbose "Retrieving result data"
+
+    $Url = "${cx_sast_server}/cxwebinterface/odata/v1/Projects?`$select=Id,LastScanId"
+    try {
+        $response = odata -Uri $Url
+        $projects = @{}
+        $response | Select-Object -ExpandProperty Value | ForEach-Object {
+            $projectId = "$($_.Id)"
+            $lastScanId = $_.LastScanId
+
+            if (-Not $lastScanId) {
+                Write-Verbose "Project ${projectId} has no last scan"
+                return
+            }
+
+            Write-Progress -Activity "Retrieving Results"
+            Write-Verbose "Retrieving result data for scan ${lastScanId} (project ${projectId})"
+
+            $Url = "${cx_sast_server}/cxwebinterface/odata/v1/Scans?`$filter=Id%20eq%20${lastScanId}%20and%20ScanRequestedOn%20gt%20${start_date}Z%20and%20ScanRequestedOn%20lt%20${end_date}z&`$select=Id&`$expand=Results(`$select=Id,ScanId,ResultId,StateId;`$expand=State)"
+            Write-Verbose "URL is ${Url}"
+
+            $response = odata -Uri $Url
+
+            if (-Not $Response.Value) {
+                Write-Verbose "No matching scan found in the specified date range for project ${projectId}"
+                return
+            }
+
+            $response | Select-Object -ExpandProperty Value | ForEach-Object {
+                if ( -not $projects.ContainsKey($projectId) ) {
+                    $projects[$projectId] = @{
+                        LastScanId = ${lastScanId}
+                        Results = @{}
+                    }
+                }
+
+                Foreach ( $result in $_.Results ) {
+                    $stateId = "$($result.StateId)"
+                    $stateName = "$($result.State.Name)"
+                    $projects[$projectId]['Results'][$stateName] = $projects[$projectId]['Results'][$stateName] + 1
+                }
+            }
+        }
+
+        # Convert projects hashmap to an array
+        $newProjects = @()
+        Foreach ( $projectId in $projects.Keys ) {
+            $project = @{
+                ProjectId = $projectId
+                LastScanId = $projects.$projectId.LastScanId
+                Results = @()
+            }
+            Foreach ( $stateName in $projects.$projectId.Results.Keys ) {
+                $result = @{
+                    StateName = $stateName
+                    Count = $projects.$projectId.Results.$stateName
+                }
+                $project.Results += $result
+            }
+            $newProjects += $project
+        }
+
+        $response = @{
+            "Projects" = $newProjects
+        }
+
+        $response | ConvertTo-Json -Compress -Depth 4 | Out-File -FilePath $outputFile -Encoding utf8
+    }
+    catch {
+        Write-Host "Exception:" $_
+        Write-Host "StatusCode:" $_.Exception.Response.StatusCode.value__
+        Write-Host "StatusDescription:" $_.Exception.Response.StatusDescription
+        Write-Host $Url
+        Write-Host "An error has prevented this script from collecting result Odata."
+        exit(-1)
+    }
 }
 
 try
 {
-    
-    $response = Invoke-WebRequest -Uri $Url -Credential $cred -OutFile data.txt -ErrorAction Stop
-    # This will only execute if the Invoke-WebRequest is successful.
-    $StatusCode = $Response.StatusCode
-    Read-Host -Prompt "The script was successful. Please send the 'data.txt' file in this directory to your Checkmarx Engineer. Press Enter to exit"
+    $files = @(".\scan-data.json")
+    getScanOdata($files[0])
+    if ( $results) {
+        $files += ".\result-data.json"
+        getResultOdata($files[1])
+    }
+    # Compress-Archive was introduced in PowerShell version 5.
+    if ($PSVersionTable.PSVersion.Major -gt 4) {
+        Compress-Archive -Path $files -DestinationPath ".\data.zip" -Force
+        Remove-Item -Path $files
+        Read-Host -Prompt "The script was successful. Please send the data.zip file in this directory to your Checkmarx Engineer. Press Enter to exit"
+    }
+    else {
+        Read-Host -Prompt "The script was successful. Please send the ${files} file(s) in this directory to your Checkmarx Engineer. Press Enter to exit"
+    }
 }
 catch
 {
+    Write-Host "Exception:" $_
     Write-Error $_.Exception.ToString()
-    Write-Host "StatusCode:" $_.Exception.Response.StatusCode.value__ 
+    Write-Host "StatusCode:" $_.Exception.Response.StatusCode.value__
     Write-Host "StatusDescription:" $_.Exception.Response.StatusDescription
-    Write-Host ""
-    Write-Host ""
-    Write-Host $Url
-    Read-Host -Prompt "An Error has prevented this script from being successful. Press paste the above Odata query in your browser..."
+    Read-Host -Prompt "The above error occurred. Press Enter to exit."
 }
-

--- a/engineering-health-check/cxInsight_9_0.ps1
+++ b/engineering-health-check/cxInsight_9_0.ps1
@@ -66,14 +66,19 @@ function getOAuth2Token() {
         client_secret = $clientSecret
     }
 
+    $cxargs = @{
+        Uri = "${serverRestEndpoint}auth/identity/connect/token"
+        Method = "Post"
+        Body = $body
+        ContentType =  "application/x-www-form-urlencoded"
+    }
+    if ($bypassProxy) {
+        $cxargs.NoProxy = $true
+    }
+
     Write-Verbose "Retrieving OAuth2 token"
     try {
-        if ($bypassProxy) {
-            $response = Invoke-RestMethod -noProxy -uri "${serverRestEndpoint}auth/identity/connect/token" -method post -body $body -contenttype 'application/x-www-form-urlencoded'
-        }
-        else {
-            $response = Invoke-RestMethod -uri "${serverRestEndpoint}auth/identity/connect/token" -method post -body $body -contenttype 'application/x-www-form-urlencoded'
-        }
+        $response = Invoke-RestMethod @cxargs
     }
     catch {
         Write-Host "Exception:" $_
@@ -89,6 +94,33 @@ function getOAuth2Token() {
 Write-Host "Running Script on Version " (get-host).Version
 $token = getOAuth2Token
 
+function odata() {
+    param (
+        $Uri,
+        $OutFile
+    )
+
+    $headers = @{
+        Authorization = $token
+    }
+    $cxargs = @{
+        Uri = $Uri
+        Headers = $headers
+        Method = "Get"
+    }
+    if ($AllowUnencryptedAuthenticationresults) {
+        $cxargs.AllowUnencryptedAuthentication = $true
+    }
+    if ($bypassProxy) {
+        $cxargs.NoProxy = $true
+    }
+    if ($OutFile) {
+        $cxargs.OutFile = $OutFile
+    }
+
+    return Invoke-RestMethod @cxargs
+}
+
 function getScanOdata {
     param (
         $outputFile
@@ -96,16 +128,8 @@ function getScanOdata {
     Write-Verbose "Retrieving scan data"
 
     $Url = "${cx_sast_server}/cxwebinterface/odata/v1/Scans?`$select=Id,ProjectId,ProjectName,OwningTeamId,TeamName,ProductVersion,EngineServerId,Origin,PresetName,ScanRequestedOn,QueuedOn,EngineStartedOn,EngineFinishedOn,ScanCompletedOn,ScanDuration,FileCount,LOC,FailedLOC,TotalVulnerabilities,High,Medium,Low,Info,IsIncremental,IsLocked,IsPublic&`$expand=ScannedLanguages(`$select=LanguageName)&`$filter=ScanRequestedOn%20gt%20${start_date}Z%20and%20ScanRequestedOn%20lt%20${end_date}z"
-    $headers = @{
-        Authorization = $token
-    }
     try {
-        if ($bypassProxy) {
-            $response = Invoke-RestMethod -noProxy -uri "$Url" -method get -headers $headers -OutFile $outputFile
-        }
-        else {
-            $response = Invoke-RestMethod -uri "$Url" -method get -headers $headers -OutFile $outputFile
-        }
+        $response = odata -Uri $Url -OutFile $outputFile
     }
     catch {
         Write-Host "Exception:" $_
@@ -124,16 +148,8 @@ function getResultOData {
     Write-Verbose "Retrieving result data"
 
     $Url = "${cx_sast_server}/cxwebinterface/odata/v1/Projects?`$select=Id,LastScanId"
-    $headers = @{
-        Authorization = $token
-    }
     try {
-        if ($bypassProxy) {
-            $response = Invoke-RestMethod -noProxy -uri "$Url" -method get -headers $headers
-        }
-        else {
-            $response = Invoke-RestMethod -uri "$Url" -method get -headers $headers
-        }
+        $response = odata -Uri $url
 
         $projects = @{}
         $response | Select-Object -ExpandProperty Value | ForEach-Object {
@@ -151,13 +167,7 @@ function getResultOData {
             $Url = "${cx_sast_server}/cxwebinterface/odata/v1/Scans?`$filter=Id%20eq%20${lastScanId}%20and%20ScanRequestedOn%20gt%20${start_date}Z%20and%20ScanRequestedOn%20lt%20${end_date}z&`$select=Id&`$expand=Results(`$select=Id,ScanId,ResultId,StateId;`$expand=State)"
             Write-Verbose "URL is ${Url}"
 
-            if ($bypassProxy) {
-                $response = Invoke-RestMethod -noProxy -uri "$Url" -method get -headers $headers
-            }
-            else {
-                $response = Invoke-RestMethod -uri "$Url" -method get -headers $headers
-            }
-
+            $response = odata -Uri $Url
             if (-Not $Response.Value) {
                 Write-Verbose "No matching scan found in the specified date range for project ${projectId}"
                 return


### PR DESCRIPTION
This pull request adds support for retrieving result triage data to the `cxInsight_8_9.ps1` script (at the request of one our CSMs). Doing so required some refactoring of the way we invoke the OData APIs, so I ported this refactoring to the 9.x version of the script.