### PR TITLE
EHC: better progress reporting, command line changes and miscellaneous cosmetic tweaks

### DIFF
--- a/engineering-health-check/README.md
+++ b/engineering-health-check/README.md
@@ -32,7 +32,14 @@ Set-ItemProperty $key ConsolePrompting True
 
 ## Triage Results
 
-By default, the cxInsight_X_X.ps1 script retrieves only scan data. To also retrieve result triage data, use the `-Results` command line switch:
+When running the cxInsight_X_X.ps1 script, you must explicitly decide whether to retrieve triage results. To retrieve triage results, pass the `-Results` command line switch:
+
 ```
-./cxInsight_X_X.ps1 -Results
+.\cxInsight_X_X.ps1 -Results
+```
+
+To exclude the triage results, use the `-ExclResults` command line switch:
+
+```
+.\cxInsight_X_X.ps1 -ExclResults
 ```

--- a/engineering-health-check/README.md
+++ b/engineering-health-check/README.md
@@ -43,3 +43,11 @@ To exclude the triage results, use the `-ExclResults` command line switch:
 ```
 .\cxInsight_X_X.ps1 -ExclResults
 ```
+
+The `-ExclResults` switch takes precedence over the `-Results` switch.
+
+## Excluding Project and Team Name
+
+The `-ExclProjectName` and `-ExclTeamName` command line switches can be used to prevent the inclusion of the project name and the team name, respectively, in the scan data.
+
+For convenience, the `-ExclAll` command line switch can be used to suppress the retrieval of result data and the suppression of the project and team names.

--- a/engineering-health-check/cxInsight_8_9.ps1
+++ b/engineering-health-check/cxInsight_8_9.ps1
@@ -108,7 +108,8 @@ function getResultOData {
     param (
         $outputFile
     )
-    Write-Verbose "Retrieving result data"
+    Write-Progress -Activity "Retrieving result data" -Status "Retrieving result data for scan ${lastScanId} (project ${projectId})"
+    Write-Verbose "Retrieving result data for scan ${lastScanId} (project ${projectId})"
 
     $Url = "${cx_sast_server}/cxwebinterface/odata/v1/Projects?`$select=Id,LastScanId"
     try {

--- a/engineering-health-check/cxInsight_8_9.ps1
+++ b/engineering-health-check/cxInsight_8_9.ps1
@@ -13,8 +13,10 @@ This script will collect Scan Information that includes data about: Projects, Pr
     The end date of the date range you would like to collect data (Format: yyyy-mm-DD)
 .PARAMETER bypassProxy
     If provided, the script will attempt to bypass any proxy when invoking the CxSAST API
-.PARAMETER results
-    If provided, the script will retrieve and summarize result data as well as scan data
+.PARAMETER Results
+    If provided, the script will retrieve and summarize result data as well as scan data. Either this option or the -ExclResults option must be provided.
+.PARAMETER ExclResults
+    If provided, the script will not retrieve result data. Either this option or the -Results option must be provided.
 .PARAMETER verbose
     If provided, the script will retrieve print activity messages
 .EXAMPLE
@@ -45,8 +47,16 @@ param(
     $results,
     [Parameter(Mandatory=$False)]
     [switch]
+    $exclresults,
+    [Parameter(Mandatory=$False)]
+    [switch]
     $AllowUnencryptedAuthenticationresults
     )
+
+if ( ! ( $results -or $exclresults ) ) {
+    Write-Error "Either -Results or -ExclResults must be provided"
+    exit
+}
 
 ###### Do Not Change The Following Configs ######
 $grantType = "password"

--- a/engineering-health-check/cxInsight_8_9.ps1
+++ b/engineering-health-check/cxInsight_8_9.ps1
@@ -80,6 +80,16 @@ if ( $exclResults -or $exclAll ) {
     }
 }
 
+# Make sure start and end date have been provided in the correct
+# format
+try {
+    $tmp = [datetime]::ParseExact($start_date, "yyyy-MM-dd", $null)
+    $tmp = [datetime]::ParseExact($end_date, "yyyy-MM-dd", $null)
+} catch {
+    Write-Error "Start and end dates must be in YYYY-MM-DD format"
+    exit
+}
+
 ###### Do Not Change The Following Configs ######
 $grantType = "password"
 $scope = "sast_rest_api"

--- a/engineering-health-check/cxInsight_8_9.ps1
+++ b/engineering-health-check/cxInsight_8_9.ps1
@@ -17,6 +17,12 @@ This script will collect Scan Information that includes data about: Projects, Pr
     If provided, the script will retrieve and summarize result data as well as scan data. Either this option or the -ExclResults option must be provided.
 .PARAMETER ExclResults
     If provided, the script will not retrieve result data. Either this option or the -Results option must be provided.
+.PARAMETER ExclProjectName
+    If provided, the project name will be excluded from the scan results.
+.PARAMETER ExclTeamName
+    If provided, the team name will be excluded from the scan results.
+.PARAMETER ExclAll
+    If provided, both the project name and the team name will be excluded from the scan results.
 .PARAMETER verbose
     If provided, the script will retrieve print activity messages
 .EXAMPLE
@@ -48,6 +54,13 @@ param(
     [Parameter(Mandatory=$False)]
     [switch]
     $exclresults,
+    $exclProjectName,
+    [Parameter(Mandatory=$False)]
+    [switch]
+    $exclTeamName,
+    [Parameter(Mandatory=$False)]
+    [switch]
+    $exclAll,
     [Parameter(Mandatory=$False)]
     [switch]
     $AllowUnencryptedAuthenticationresults
@@ -65,6 +78,17 @@ $clientId = "resource_owner_client"
 $clientSecret = "014DF517-39D1-4453-B7B3-9930C563627C"
 
 $cred = Get-Credential -Credential $null
+
+# Data exclusion
+$projectName = "ProjectName,"
+$teamName = "TeamName,"
+
+if ( $exclProjectName -or $exclAll ) {
+    $projectName = ""
+}
+if ( $exclTeamName -or $exclAll ) {
+    $teamName = ""
+}
 
 Write-Host "Running Script on Version " (get-host).Version
 #$token = getOAuth2Token
@@ -99,7 +123,7 @@ function getScanOdata {
     )
     Write-Verbose "Retrieving scan data"
 
-    $Url = "${cx_sast_server}/cxwebinterface/odata/v1/Scans?`$select=Id,ProjectId,ProjectName,OwningTeamId,TeamName,ProductVersion,EngineServerId,Origin,PresetName,ScanRequestedOn,QueuedOn,EngineStartedOn,EngineFinishedOn,ScanCompletedOn,ScanDuration,FileCount,LOC,FailedLOC,TotalVulnerabilities,High,Medium,Low,Info,IsIncremental,IsLocked,IsPublic&`$expand=ScannedLanguages(`$select=LanguageName)&`$filter=ScanRequestedOn%20gt%20${start_date}Z%20and%20ScanRequestedOn%20lt%20${end_date}z"
+    $Url = "${cx_sast_server}/cxwebinterface/odata/v1/Scans?`$select=Id,ProjectId,${ProjectName}OwningTeamId,${TeamName}ProductVersion,EngineServerId,Origin,PresetName,ScanRequestedOn,QueuedOn,EngineStartedOn,EngineFinishedOn,ScanCompletedOn,ScanDuration,FileCount,LOC,FailedLOC,${vulnerabilities}IsIncremental,IsLocked,IsPublic&`$expand=ScannedLanguages(`$select=LanguageName)&`$filter=ScanRequestedOn%20gt%20${start_date}Z%20and%20ScanRequestedOn%20lt%20${end_date}z"
     try {
         $response = odata -Uri $Url -OutFile $outputFile
     }

--- a/engineering-health-check/cxInsight_9_0.ps1
+++ b/engineering-health-check/cxInsight_9_0.ps1
@@ -17,6 +17,12 @@ This script will collect Scan Information that includes data about: Projects, Pr
     If provided, the script will retrieve and summarize result data as well as scan data. Either this or the -ExclResults option must be provided.
 .PARAMETER ExclResults
     If provided, the script will not retrieve result. Either this or the -Results option must be provided.
+.PARAMETER ExclProjectName
+    If provided, the project name will be excluded from the scan results.
+.PARAMETER ExclTeamName
+    If provided, the team name will be excluded from the scan results.
+.PARAMETER ExclAll
+    If provided, both the project name and the team name will be excluded from the scan results.
 .PARAMETER verbose
     If provided, the script will retrieve print activity messages
 .EXAMPLE
@@ -47,7 +53,16 @@ param(
     $results,
     [Parameter(Mandatory=$False)]
     [switch]
-    $exclresults
+    $exclresults,
+    [Parameter(Mandatory=$False)]
+    [switch]
+    $exclProjectName,
+    [Parameter(Mandatory=$False)]
+    [switch]
+    $exclTeamName,
+    [Parameter(Mandatory=$False)]
+    [switch]
+    $exclAll
     )
 
 if ( ! ( $results -or $exclresults ) ) {
@@ -64,6 +79,17 @@ $clientSecret = "014DF517-39D1-4453-B7B3-9930C563627C"
 $cred = Get-Credential -Credential $null
 $cxUsername = $cred.UserName
 $cxPassword = $cred.GetNetworkCredential().password
+
+# Data exclusion
+$projectName = "ProjectName,"
+$teamName = "TeamName,"
+
+if ( $exclProjectName -or $exclAll ) {
+    $projectName = ""
+}
+if ( $exclTeamName -or $exclAll ) {
+    $teamName = ""
+}
 
 $serverRestEndpoint = $cx_sast_server + "/cxrestapi/"
 function getOAuth2Token() {
@@ -137,7 +163,7 @@ function getScanOdata {
     )
     Write-Verbose "Retrieving scan data"
 
-    $Url = "${cx_sast_server}/cxwebinterface/odata/v1/Scans?`$select=Id,ProjectId,ProjectName,OwningTeamId,TeamName,ProductVersion,EngineServerId,Origin,PresetName,ScanRequestedOn,QueuedOn,EngineStartedOn,EngineFinishedOn,ScanCompletedOn,ScanDuration,FileCount,LOC,FailedLOC,TotalVulnerabilities,High,Medium,Low,Info,IsIncremental,IsLocked,IsPublic&`$expand=ScannedLanguages(`$select=LanguageName)&`$filter=ScanRequestedOn%20gt%20${start_date}Z%20and%20ScanRequestedOn%20lt%20${end_date}z"
+    $Url = "${cx_sast_server}/cxwebinterface/odata/v1/Scans?`$select=Id,ProjectId,${ProjectName}OwningTeamId,${TeamName}ProductVersion,EngineServerId,Origin,PresetName,ScanRequestedOn,QueuedOn,EngineStartedOn,EngineFinishedOn,ScanCompletedOn,ScanDuration,FileCount,LOC,FailedLOC,${vulnerabilities}IsIncremental,IsLocked,IsPublic&`$expand=ScannedLanguages(`$select=LanguageName)&`$filter=ScanRequestedOn%20gt%20${start_date}Z%20and%20ScanRequestedOn%20lt%20${end_date}z"
     try {
         $response = odata -Uri $Url -OutFile $outputFile
     }

--- a/engineering-health-check/cxInsight_9_0.ps1
+++ b/engineering-health-check/cxInsight_9_0.ps1
@@ -79,6 +79,16 @@ if ( $exclResults -or $exclAll ) {
     }
 }
 
+# Make sure start and end date have been provided in the correct
+# format
+try {
+    $tmp = [datetime]::ParseExact($start_date, "yyyy-MM-dd", $null)
+    $tmp = [datetime]::ParseExact($end_date, "yyyy-MM-dd", $null)
+} catch {
+    Write-Error "Start and end dates must be in YYYY-MM-DD format"
+    exit
+}
+
 ###### Do Not Change The Following Configs ######
 $grantType = "password"
 $scope = "access_control_api sast_api"

--- a/engineering-health-check/cxInsight_9_0.ps1
+++ b/engineering-health-check/cxInsight_9_0.ps1
@@ -161,7 +161,7 @@ function getResultOData {
                 return
             }
 
-            Write-Progress -Activity "Retrieving Results"
+            Write-Progress -Activity "Retrieving Results" -Status "Retrieving result data for scan ${lastScanId} (project ${projectId})"
             Write-Verbose "Retrieving result data for scan ${lastScanId} (project ${projectId})"
 
             $Url = "${cx_sast_server}/cxwebinterface/odata/v1/Scans?`$filter=Id%20eq%20${lastScanId}%20and%20ScanRequestedOn%20gt%20${start_date}Z%20and%20ScanRequestedOn%20lt%20${end_date}z&`$select=Id&`$expand=Results(`$select=Id,ScanId,ResultId,StateId;`$expand=State)"

--- a/engineering-health-check/cxInsight_9_0.ps1
+++ b/engineering-health-check/cxInsight_9_0.ps1
@@ -13,10 +13,12 @@ This script will collect Scan Information that includes data about: Projects, Pr
     The end date of the date range you would like to collect data (Format: yyyy-mm-DD)
 .PARAMETER bypassProxy
     If provided, the script will attempt to bypass any proxy when invoking the CxSAST API
-.PARAMETER results
-If provided, the script will retrieve and summarize result data as well as scan data
+.PARAMETER Results
+    If provided, the script will retrieve and summarize result data as well as scan data. Either this or the -ExclResults option must be provided.
+.PARAMETER ExclResults
+    If provided, the script will not retrieve result. Either this or the -Results option must be provided.
 .PARAMETER verbose
-If provided, the script will retrieve print activity messages
+    If provided, the script will retrieve print activity messages
 .EXAMPLE
     C:\PS> .\cxInsight_9_0.ps1 -cx_sast_server https://customerurl.checkmarx.net
 .EXAMPLE
@@ -42,8 +44,16 @@ param(
     $bypassProxy,
     [Parameter(Mandatory=$False)]
     [switch]
-    $results
+    $results,
+    [Parameter(Mandatory=$False)]
+    [switch]
+    $exclresults
     )
+
+if ( ! ( $results -or $exclresults ) ) {
+    Write-Error "Either -Results or -ExclResults must be provided"
+    exit
+}
 
 ###### Do Not Change The Following Configs ######
 $grantType = "password"


### PR DESCRIPTION
The `Write-Progress` cmdlet now displays the project and scan identifiers as we retrieve the result data. This shows that the script is working.

Added the `-ExclProjectName` and `-ExclTeamName` command line options to suppress the project and team names in the scan data (anecdotally, customers used to edit the script to remove these).

Added the `-ExclAll` command line option to exclude both the project and team name as well as the result data.

The user must now provide at least one of the `-Results`, `-ExclResults` or `-ExclAll` options (i.e., we want the user to explicitly decide whether or not to retrieve result data).

Make sure that, if the user provides the start or end date, that these are in the correct format.

Numerous cosmetic tweaks to align the two versions of the script.

Update the date in the header comments.