### PR TITLE
EHC: add notes on LDAP users and permissions.

### DIFF
--- a/engineering-health-check/README.md
+++ b/engineering-health-check/README.md
@@ -54,7 +54,7 @@ For convenience, the `-ExclAll` command line switch can be used to suppress the 
 
 ## LDAP Users
 
-It is possible to use the credentials of an LDAP user to run the `cxInsight_X_X.ps1` script. In this case, the username passed to the script should be of the form *<authentication provider name>\<username>*. The authentication provider name can be seen in the “Sign in method” dropdown menu of the CxSAST portal’s login screen.
+It is possible to use the credentials of an LDAP user to run the `cxInsight_X_X.ps1` script. In this case, the username passed to the script should be of the form *authentication provider name\username*. The authentication provider name can be seen in the “Sign in method” dropdown menu of the CxSAST portal’s login screen.
 
 Note that it is not possible to use the credentials of a SAML user.
 

--- a/engineering-health-check/README.md
+++ b/engineering-health-check/README.md
@@ -51,3 +51,13 @@ The `-ExclResults` switch takes precedence over the `-Results` switch.
 The `-ExclProjectName` and `-ExclTeamName` command line switches can be used to prevent the inclusion of the project name and the team name, respectively, in the scan data.
 
 For convenience, the `-ExclAll` command line switch can be used to suppress the retrieval of result data and the suppression of the project and team names.
+
+## LDAP Users
+
+It is possible to use the credentials of an LDAP user to run the `cxInsight_X_X.ps1` script. In this case, the username passed to the script should be of the form *<authentication provider name>\<username>*. The authentication provider name can be seen in the “Sign in method” dropdown menu of the CxSAST portal’s login screen.
+
+Note that it is not possible to use the credentials of a SAML user.
+
+## Permissions
+
+The user whose credentials are used to run the `cxInsight_X_X.ps1` script must be assigned a role that has the Sast API permission (needed as the script uses the CxSAST OData API). This is the only permission required.


### PR DESCRIPTION
Add information to the EHC script's README about LDAP users and the permissions needed to run the script.