### PR TITLE
Retrieve license data and engine information

### DIFF
--- a/engineering-health-check/README.md
+++ b/engineering-health-check/README.md
@@ -1,7 +1,7 @@
 # engineering-health-check
 
 These Powershell scripts are used to retrieve  CxSAST Scan Data for Insight Analysis in the Engineering Health Check.
-The script will collect scan Information that includes data about: Projects, Presets, Teams, Engines, and Result Metrics
+The script will collect scan Information that includes data about: Projects, Presets, Teams, Engines, and Result Metrics. The 9.0 version of the script also retrieves license data (if the SAST version supports this) and engine information.
 The script also optionally collects and generates a summary of the result data for the last full scan of each project. Note that it is possible for the last scan of a project to have no results (e.g., if there were no code changes).
 
 * Use the corresponding script for the version of CxSAST that is installed.

--- a/engineering-health-check/cxInsight_9_0.ps1
+++ b/engineering-health-check/cxInsight_9_0.ps1
@@ -196,7 +196,6 @@ function getScanOdata {
         Write-Host "StatusDescription:" $_.Exception.Response.StatusDescription
         Write-Host $Url
         Write-Host "An error has prevented this script from collecting scan Odata."
-        return $false
     }
 }
 


### PR DESCRIPTION
Retrieve additional information to help with the Engineering Health Check. We now retrieve the license data (if running against a version of CxSAST that supports this) and information about the scanning engines.