### PR TITLE
EHC: add the split_branch_scans.ps1 script

### DIFF
--- a/engineering-health-check/README.md
+++ b/engineering-health-check/README.md
@@ -61,3 +61,27 @@ Note that it is not possible to use the credentials of a SAML user.
 ## Permissions
 
 The user whose credentials are used to run the `cxInsight_X_X.ps1` script must be assigned a role that has the Sast API permission (needed as the script uses the CxSAST OData API). This is the only permission required.
+
+## Scans Created When Branching Projects
+
+When a project is branched in CxSAST, a duplicate scan record is made
+of the last scan completed before the branching. This means that, if a
+project was both scanned and branched during the period for which the
+enginerring health check data was extracted, the resultant
+`scan-data.json` file will contain two entries for the same scan.
+
+The `split_branch_scans.ps1` script can be used to split the
+`scan-data.json` file into two files, one containing the /base/ scans,
+and the other containing the /branched/ scans. These files will be
+named `scan-data-base.json` and `scan-data-branch.json`
+respectively. The recors in the latter file will include an additional
+property, `OrigScanId`, which gives the number of the corresponding
+scan in the /base/ file.
+
+### Usage
+
+The `split_branch_scans.ps1` script expects the name of the file
+containing the original scan data to be passed on the command line:
+
+```
+PS C:\...\ehc> .\split_branch_scans.ps1 -FileName scan-data.json

--- a/engineering-health-check/split_branch_scans.ps1
+++ b/engineering-health-check/split_branch_scans.ps1
@@ -1,0 +1,69 @@
+<#
+.SYNOPSIS
+Split out branch scans from EHC scan data
+.DESCRIPTION
+When a project is branched in CxSAST, a copy is made of the last scan
+of the project that it was branched from. This script takes a JSON
+file of scan data, extracted by the cxInsight script, and splits it
+into two JSON files, one containing the actual scans that were
+performed, and one containing the scans created on project branching.
+.PARAMETER FileName
+The name of the file containing the EHC scan data
+.EXAMPLE
+PS C:\> .\split_branch_scans.ps1 scan-data.json
+.NOTES
+Author : Checkmarx Professional Services
+Date   : 2023-06-30
+Updated: 2023-06-30
+#>
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$FileName
+)
+
+$ScanData = Get-Content $FileName | ConvertFrom-Json
+$ScanKeys = @{}
+$BaseScanData = @{
+    '@odata.context' = $ScanData."@odata.context"
+    value = [System.Collections.ArrayList]::new()
+}
+$BranchScanData = @{
+    # We intentionlly do not add the @odata.context property as, later, we
+    # add a property (the original scan Id) and it doesn't seem worthwhile
+    # going to the trouble of creating a fake context.
+    value = [System.Collections.ArrayList]::new()
+}
+
+foreach ($scan in $ScanData.value) {
+    $ScanKey = @($scan.OwningTeamId, $Scan.ProductVersion,
+                 $scan.EngineServerId, $scan.Origin, $scan.PresetName,
+                 $scan.RequestedOn, $scan.QueuedOn, $scan.EngineStartedOn,
+                 $scan.EngineFinishedOn, $scan.ScanCompletedOn,
+                 $scan.ScanDuration, $scan.FileCount, $scan.LOC,
+                 $scan.FailedLOC, $scan.TotalVulnerabilities,
+                 $scan.High, $scan.Medium, $scan.Low, $scan.Info,
+                 $scan.IsIncremental, $scan.IsPublic) -join '-'
+    if ($ScanKeys.ContainsKey($ScanKey)) {
+        $OrigScanId = $ScanKeys[$ScanKey]
+        $Scan | Add-Member -MemberType NoteProperty -Name OrigScanId -Value $OrigScanId
+        $_ = $BranchScanData.value.Add($scan)
+    } else {
+        $_ = $BaseScanData.value.Add($scan)
+        $ScanKeys[$ScanKey] = $scan.Id
+    }
+}
+
+$bits = $FileName.split(".")
+if ($bits.Count -gt 1) {
+    $n = $bits.Count - 2
+    $root = $bits[0..$n] -join "."
+    $suff = $bits[$bits.Count - 1]
+    $BaseScanFileName = $root + "-base." + $suff
+    $BranchScanFileName = $root + "-branch." + $suff
+} else {
+    $BaseScanFileName = $FileName + "-base"
+    $BranchScanFileName = $FileName + "-branch"
+}
+
+$BaseScanData | ConvertTo-Json -Depth 4 | Out-File $BaseScanFileName
+$BranchScanData | ConvertTo-Json -Depth 4 | Out-File $BranchScanFileName


### PR DESCRIPTION
Add the `split_branch_scans.ps1` script. This script is used to postprocess the `scan-data.json` file extracted by the `cxInsight_9_0.ps1` script. It splits the scan data into two sets of scans: base scans and scans created due to project branching.