### PR TITLE
SAST-Create-report: bug fix: provide default for report_teams param

### DIFF
--- a/cx-sast-shell-tools/SAST-Create-Report.ps1
+++ b/cx-sast-shell-tools/SAST-Create-Report.ps1
@@ -42,7 +42,7 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$report_type = "PDF",
     [Parameter(Mandatory = $false)]
-    [string[]]$report_teams
+    [string[]]$report_teams = @()
 )
 
 . "$PSScriptRoot/support/debug.ps1"


### PR DESCRIPTION
We set the default value of the `report_teams` parameter to an empty array so that when we pipe it to the `ForEach-Object` we don't get:
```
+     if ( ! $_.StartsWith("/") ) {
+          ~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull
```