### PR TITLE
SAST reports: escape special XML characters in password

### DIFF
--- a/cx-sast-shell-tools/support/soap/webinterface/login.ps1
+++ b/cx-sast-shell-tools/support/soap/webinterface/login.ps1
@@ -4,7 +4,10 @@ param(
     [String]$password
 )
 
-
+# Escape &, < and > characters in the password. As the password occurs
+# as character data, we do not need to escape single or double
+# quotation marks.
+$password = $password -replace "&", "&amp;" -replace "<", "&lt;" -replace ">", "&gt;"
 
 $soap_path = "/cxwebinterface/Portal/CxWebService.asmx"
 


### PR DESCRIPTION
The `SAST-Create-Report.ps1` script initially tries to use the SOAP API to login. If the user's password includes a &, < or >, this will result in malformed XML. With this change, these characters are escaped.