### PR TITLE
EHC: reject CxSAST server URLs that do not begin with the URL scheme

### DIFF
--- a/engineering-health-check/cxInsight_8_9.ps1
+++ b/engineering-health-check/cxInsight_8_9.ps1
@@ -68,6 +68,11 @@ param(
     $AllowUnencryptedAuthenticationresults
     )
 
+if ( ! ($cx_sast_server -match "^https?://") ) {
+    Write-Error "SAST server URL must start with http:// or https://"
+    exit
+}
+
 if ( ! ( $results -or $exclresults -or $exclAll ) ) {
     Write-Error "Either -Results, -ExclResults or -ExclAll must be provided"
     exit

--- a/engineering-health-check/cxInsight_9_0.ps1
+++ b/engineering-health-check/cxInsight_9_0.ps1
@@ -67,6 +67,11 @@ param(
     $exclAll
     )
 
+if ( ! ($cx_sast_server -match "^https?://") ) {
+    Write-Error "SAST server URL must start with http:// or https://"
+    exit
+}
+
 if ( ! ( $results -or $exclresults -or $exclAll ) ) {
     Write-Error "Either -Results, -ExclResults or -ExclAll must be provided"
     exit


### PR DESCRIPTION
With this change, we require that the value given for the CxSAST server URL start with either "http://" or "https://". This avoids an easy user mistake which produces rather cryptic error messages.