### PR TITLE
SAST-Create-Report: add pause between report generation requests

### DIFF
--- a/cx-sast-shell-tools/SAST-Create-Report.ps1
+++ b/cx-sast-shell-tools/SAST-Create-Report.ps1
@@ -30,6 +30,9 @@
 
     .PARAMETER report_teams
         (Optional) Only generate reports for projects belonging to the specified teams
+
+    .PARAMETER pause
+        (Optional) Pause for this many seconds between report requests
 #>
 param(
     [Parameter(Mandatory = $true)]
@@ -42,7 +45,9 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$report_type = "PDF",
     [Parameter(Mandatory = $false)]
-    [string[]]$report_teams = @()
+    [string[]]$report_teams = @(),
+    [Parameter(Mandatory = $false)]
+    [int]$pause = 5
 )
 
 . "$PSScriptRoot/support/debug.ps1"
@@ -117,6 +122,10 @@ $projects | % {
             #generate the report
             $report = &"$PSScriptRoot/support/soap/generate_report.ps1" $session $scans.id $report_type
             $report_index.Add($scans.id, $report)
+            # If we send too many report generation requests at more or less
+            # the same time, we can overload the JobsManager. So we pause
+            # between requests.
+            Start-Sleep -Seconds $pause
         } else {
             Write-Debug "No scans found for project $($_.id))"
         }


### PR DESCRIPTION
This PR adds an optional command line option, -pause, which specifies the time the script should wait between report generation requests. If these requests happen too quickly, the Jobs Manager can be overloaded. The default pause is 5 seconds.

See case 00229746.