### PR TITLE
EHC: Fix support for critical severity

### DIFF
--- a/engineering-health-check/cxInsight_9_0.ps1
+++ b/engineering-health-check/cxInsight_9_0.ps1
@@ -183,13 +183,24 @@ function odata() {
 
 function getScanOdata {
     param (
-        $fileList
+        $fileList,
+        $version
     )
 
     $outputFile = ".\scan-data.json"
     Write-Verbose "Retrieving scan data"
 
-    $Url = "${cx_sast_server}/cxwebinterface/odata/v1/Scans?`$select=Id,ProjectId,${ProjectName}OwningTeamId,${TeamName}ProductVersion,EngineServerId,Origin,PresetName,ScanRequestedOn,QueuedOn,EngineStartedOn,EngineFinishedOn,ScanCompletedOn,ScanDuration,FileCount,LOC,FailedLOC,TotalVulnerabilities,Critical,High,Medium,Low,Info,IsIncremental,IsLocked,IsPublic&`$expand=ScannedLanguages(`$select=LanguageName),Project(`$select=EngineConfigurationId;`$expand=EngineConfiguration)&`$filter=ScanRequestedOn%20gt%20${start_date}Z%20and%20ScanRequestedOn%20lt%20${end_date}z"
+    switch -Wildcard ($version.version) {
+        9.7.* {
+            $Critical = "Critical,"
+        }
+        default {
+            $Critical = ""
+        }
+    }
+
+    $Url = "${cx_sast_server}/cxwebinterface/odata/v1/Scans?`$select=Id,ProjectId,${ProjectName}OwningTeamId,${TeamName}ProductVersion,EngineServerId,Origin,PresetName,ScanRequestedOn,QueuedOn,EngineStartedOn,EngineFinishedOn,ScanCompletedOn,ScanDuration,FileCount,LOC,FailedLOC,TotalVulnerabilities,${Critical}High,Medium,Low,Info,IsIncremental,IsLocked,IsPublic&`$expand=ScannedLanguages(`$select=LanguageName),Project(`$select=EngineConfigurationId;`$expand=EngineConfiguration)&`$filter=ScanRequestedOn%20gt%20${start_date}Z%20and%20ScanRequestedOn%20lt%20${end_date}z"
+    Write-Verbose "`$Url: $Url"
     try {
         $response = odata -Uri $Url -OutFile $outputFile
         [void]$fileList.Add($outputFile)
@@ -338,10 +349,32 @@ function getEngineData {
     }
 }
 
+function getSASTVersion {
+
+    Write-Verbose "Retrieving SAST version"
+
+    $Url = "${cx_sast_server}/cxrestapi/system/version"
+    try {
+        $response = odata -Uri $Url
+        Write-Host "SAST version: ${response}"
+    }
+    catch {
+        Write-Host "Exception:" $_ -ForegroundColor "Red"
+        Write-Host $_.ScriptStackTrace -ForegroundColor "DarkGray"
+        Write-Host "StatusCode:" $_.Exception.Response.StatusCode.value__
+        Write-Host "StatusDescription:" $_.Exception.Response.StatusDescription
+        Write-Host $Url
+        Write-Host "An error has prevented this script from retrieving the system version."
+        return $false
+    }
+    return $response
+}
+
 try
 {
     $files = [System.Collections.ArrayList]::new()
-    getScanOdata $files
+    $version = getSASTVersion
+    getScanOdata $files $version
     getEngineData $files
     getLicenseData $files
     if ($results) {


### PR DESCRIPTION
The previous change to enable support for critical severity results was broken. The OData API, when a non-existent property is specified by the `$select` query option, ignores all query options (i.e., in the case of the `cxInsight_9_0.ps1` script it returns all scans but does not perform any expansions).

The `cxInsight_9_0.ps1` script now invokes the `/cxrestapi/system/version` endpoint to find the version of CxSAST being queried. Based on the version information it decides whether to request the number of critical severity results.