### PR TITLE
EHC: Use System URI Classes

### DIFF
--- a/engineering-health-check/cxInsight_9_0.ps1
+++ b/engineering-health-check/cxInsight_9_0.ps1
@@ -38,7 +38,7 @@ This script will collect Scan Information that includes data about: Projects, Pr
 .NOTES
     Author: Checkmarx
     Date:   April 13, 2020
-    Updated: March 21, 2025
+    Updated: June 11, 2025
 #>
 
 param(


### PR DESCRIPTION
Rather than parsing the CxSAST server URI ourselves using regular expressions, we now use the System.URI class. As before, we validate that the URI scheme is either "http" or "https", but now we also truncate any path elements provided by the user (a common mistake is to include "/CxWebClient").
