### PR TITLE
security: pin docker images to sha256 digests

### DIFF
--- a/CxFlowDemoInstance/docker-compose.yml
+++ b/CxFlowDemoInstance/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
 
   jira-server:
-    image: atlassian/jira-software:latest
+    image: atlassian/jira-software:latest@sha256:01a591327d2f5a867f41e8a4eebdafbd1950a669eb64110ef044042733e79834
     volumes:
       - jira_data:/var/atlassian/application-data/jira
     dns:

--- a/JenkinsDemoInstance/cluster/Dockerfile-agent-jdk8
+++ b/JenkinsDemoInstance/cluster/Dockerfile-agent-jdk8
@@ -1,4 +1,4 @@
-FROM openjdk:8u212-jdk-stretch
+FROM openjdk:8u212-jdk-stretch@sha256:dfa24d97c724814b56b3735fb0b2570576f0dc1036c8060e4913b6b95f1da0aa
 
 RUN apt-get update && \
 apt-get install -y maven gradle && \


### PR DESCRIPTION
Replaces 2 image references across 2 files with @sha256:<digest>
pinned forms. Defends against tag mutation / supply-chain attacks.

Pinned images:
  - atlassian/jira-software:latest -> atlassian/jira-software:latest@sha256:01a591327d2f5a867f41e8a4eebdafbd1950a669eb64110ef044042733e79834
  - openjdk:8u212-jdk-stretch -> openjdk:8u212-jdk-stretch@sha256:dfa24d97c724814b56b3735fb0b2570576f0dc1036c8060e4913b6b95f1da0aa

Generated by docker-image-pinner from plan-dev-4.csv.